### PR TITLE
feat(ui): config screen and dynamic tap selection

### DIFF
--- a/include/api_client.h
+++ b/include/api_client.h
@@ -14,6 +14,18 @@
 /** Maximum length for string fields from the API */
 static constexpr uint8_t API_STR_LEN = 128;
 
+#define MAX_TAPS_IN_LIST 10
+
+struct TapInfo {
+    int id;                   ///< Tap ID
+    char name[API_STR_LEN];   ///< Name of the tap
+};
+
+struct TapList {
+    TapInfo taps[MAX_TAPS_IN_LIST];
+    uint8_t count;
+};
+
 /**
  * @brief Data received from GET /api/taps/{tapID}/display
  */
@@ -44,3 +56,10 @@ bool fetchTapDisplay(TapData& out);
  * @return true on success (HTTP 200/201), false otherwise.
  */
 bool postPour(const char* kegId, float liters);
+
+/**
+ * @brief Fetch list of available taps.
+ * @param[out] out  Populated TapList struct on success.
+ * @return true on success, false on HTTP/parse error.
+ */
+bool fetchTapsList(TapList& out);

--- a/include/config.h.example
+++ b/include/config.h.example
@@ -15,17 +15,16 @@
 // goTapList API Settings
 // ==========================================
 // Base URL for the goTapList backend API (no trailing slash)
-#define API_BASE_URL "http://192.168.1.100:8080/api"
+#define API_BASE_URL "http://192.168.10.115:18080/api"
 
 // ==========================================
 // Device Settings
 // ==========================================
-// ID of the tap this ESP32 is physically attached to
+// Unique ID for the kran (tap) this ESP32 is physically attached to.
+// This matches the tap ID/slug in your goTapList dashboard.
 #define TAP_ID "tap-01"
 
-// Keg ID – used in POST /api/kegs/{kegID}/pour.
-// In a future iteration this will be fetched dynamically from the display API.
-#define KEG_ID "keg-01"
+// Keg ID – now fetched dynamically from the API based on TAP_ID.
 
 // How often (ms) to refresh tap data from the API
 #define DISPLAY_REFRESH_INTERVAL_MS 60000

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -18,7 +18,12 @@
 /*====================
    Memory
  *====================*/
-#define LV_MEM_SIZE (64 * 1024U)   /* 64 KB for LVGL objects (internal DRAM) */
+#define LV_USE_STDLIB_MALLOC    1
+
+#define LV_USE_STDLIB_STRING    1
+#define LV_USE_STDLIB_SPRINTF   1
+#define LV_USE_FS_MEMFS         1
+#define LV_FS_MEMFS_LETTER     'M'
 
 /*====================
    Font support (Montserrat built-in)
@@ -26,6 +31,8 @@
 #define LV_FONT_MONTSERRAT_14 1
 #define LV_FONT_MONTSERRAT_20 1
 #define LV_FONT_MONTSERRAT_28 1
+#define LV_FONT_MONTSERRAT_32 1
+#define LV_FONT_MONTSERRAT_36 1
 #define LV_FONT_DEFAULT &lv_font_montserrat_14
 
 /*====================
@@ -33,10 +40,13 @@
  *====================*/
 /* LVGL v9: built-in JPEG decoding via tjpgd */
 #define LV_USE_TJPGD    1
-#define LV_USE_PNG      0
-#define LV_USE_BMP      0
-#define LV_USE_GIF      0
+#define LV_USE_PNG      1
+#define LV_USE_BMP      1
+#define LV_USE_GIF      1
 #define LV_USE_QRCODE   0
+
+/* Reserver plass i minnet for at fulle PNG-bilder kan pakkes ut. Dette trengs fordi LodePNG dekoder hele bildebuffere før opptegning, i motsetning til JPEG som tegnes linje for linje. */
+#define LV_CACHE_DEF_SIZE       (4 * 1024 * 1024)   /* 4 MB cache for dekodede bilder */
 
 /*====================
    Widgets

--- a/include/settings.h
+++ b/include/settings.h
@@ -1,0 +1,21 @@
+/**
+ * @file settings.h
+ * @brief Wrapper for NVS (Preferences) lagring av innstillinger som f.eks tapId.
+ */
+
+#pragma once
+
+/**
+ * @brief Initialize settings. Laster lagret tapId eller setter til default (config.h TAP_ID).
+ */
+void settingsInit();
+
+/**
+ * @brief Henter gjeldende tapId (enten lagret eller fallback).
+ */
+const char* settingsGetTapId();
+
+/**
+ * @brief Lagre ny tapId i NVS.
+ */
+void settingsSetTapId(const char* tapId);

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,6 +2,7 @@
 platform = espressif32
 board = JC8048W550C
 framework = arduino
+build_type = debug
 
 ; boards/ folder is scanned automatically by PlatformIO for custom board JSON.
 

--- a/src/api_client.cpp
+++ b/src/api_client.cpp
@@ -5,7 +5,7 @@
 
 #include "api_client.h"
 #include "config.h"
-
+#include "settings.h"
 
 #include <Arduino.h>
 #include <HTTPClient.h>
@@ -50,7 +50,7 @@ static bool httpGet(const char* url, String& responseBody) {
 bool fetchTapDisplay(TapData& out) {
     // Build URL
     char url[256];
-    snprintf(url, sizeof(url), "%s/taps/%s/display", API_BASE_URL, TAP_ID);
+    snprintf(url, sizeof(url), "%s/taps/%s/display", API_BASE_URL, settingsGetTapId());
 
     String body;
     if (!httpGet(url, body)) {
@@ -68,11 +68,23 @@ bool fetchTapDisplay(TapData& out) {
     }
 
     // Populate struct – use strlcpy to stay within buffer bounds
-    strlcpy(out.beerName,       doc["beer_name"]  | "",   sizeof(out.beerName));
-    strlcpy(out.logoUrl,        doc["logo_url"]   | "",   sizeof(out.logoUrl));
-    strlcpy(out.kegId,          doc["keg_id"]     | KEG_ID, sizeof(out.kegId));
-    out.abv              = doc["abv"]              | 0.0f;
-    out.remainingLiters  = doc["remaining_liters"] | 0.0f;
+    strlcpy(out.beerName,       doc["beerName"]   | "",   sizeof(out.beerName));
+    
+    // Logo fallback: if "beerLogo" is missing but "beerId" exists, construct the URL (like goTOVGUI)
+    const char* logo = doc["beerLogo"] | "";
+    if (logo[0] == '\0' && !doc["beerId"].isNull()) {
+        snprintf(out.logoUrl, sizeof(out.logoUrl), "%s/beers/%d/logo", API_BASE_URL, doc["beerId"].as<int>());
+    } else {
+        strlcpy(out.logoUrl, logo, sizeof(out.logoUrl));
+    }
+
+    if (out.logoUrl[0] != '\0') {
+        Serial.printf("[API] Logo URL: %s\n", out.logoUrl);
+    }
+
+    strlcpy(out.kegId,          doc["kegId"].as<String>().c_str(), sizeof(out.kegId));
+    out.abv              = doc["beerAbv"]          | 0.0f;
+    out.remainingLiters  = doc["volumeLeft"]       | 0.0f;
     out.isEmpty          = false;
 
     Serial.printf("[API] Tap data: %s (%.1f%% ABV, %.1f L left)\n",
@@ -90,8 +102,8 @@ bool postPour(const char* kegId, float liters) {
     snprintf(url, sizeof(url), "%s/kegs/%s/pour", API_BASE_URL, kegId);
 
     // Build JSON body
-    char body[64];
-    snprintf(body, sizeof(body), "{\"liters\":%.2f,\"source\":\"esp32\"}", liters);
+    char body[128];
+    snprintf(body, sizeof(body), "{\"liters\":%.2f,\"source\":\"esp32-%s\"}", liters, settingsGetTapId());
 
     HTTPClient http;
     http.setTimeout(HTTP_TIMEOUT_MS);
@@ -101,11 +113,43 @@ bool postPour(const char* kegId, float liters) {
     int code = http.POST(body);
     http.end();
 
-    if (code == HTTP_CODE_OK || code == HTTP_CODE_CREATED) {
+    if (code == HTTP_CODE_OK || code == HTTP_CODE_CREATED || code == HTTP_CODE_NO_CONTENT || code == 204) {
         Serial.printf("[API] Pour registered: %.2f L on keg %s\n", liters, kegId);
         return true;
     }
 
     Serial.printf("[API] POST pour failed: %d\n", code);
     return false;
+}
+
+bool fetchTapsList(TapList& out) {
+    out.count = 0;
+
+    char url[256];
+    snprintf(url, sizeof(url), "%s/taps", API_BASE_URL);
+
+    String body;
+    if (!httpGet(url, body)) {
+        return false;
+    }
+
+    // Taps is an array of objects
+    // Example: [{"tapId":2,"tapName":"1",...}, ...]
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, body);
+    if (err) {
+        Serial.printf("[API] fetchTapsList JSON parse error: %s\n", err.c_str());
+        return false;
+    }
+
+    JsonArray array = doc.as<JsonArray>();
+    for (JsonVariant v : array) {
+        if (out.count >= MAX_TAPS_IN_LIST) break;
+        out.taps[out.count].id = v["tapId"] | 0;
+        strlcpy(out.taps[out.count].name, v["tapName"] | "Ukjent", sizeof(out.taps[out.count].name));
+        out.count++;
+    }
+
+    Serial.printf("[API] Fetched %d taps\n", out.count);
+    return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,14 +15,16 @@
 #include <lvgl.h>
 
 #include "config.h"   // MUST be included before any module that uses its defines
+#include "settings.h"
 #include "wifi_manager.h"
 #include "api_client.h"
 #include "ui.h"
 
 // ------------------------------------------------------------------
-// Timing
+// Timing & State
 // ------------------------------------------------------------------
-static uint32_t g_lastRefreshMs = 0;
+uint32_t g_lastRefreshMs = 0;
+static bool g_isScreenSleeping = false;
 
 // ------------------------------------------------------------------
 // setup
@@ -32,11 +34,20 @@ void setup() {
     delay(500); // let monitor connect
     Serial.println("[Main] goTapFirmware starting...");
 
+    // 0. Init Settings (NVS)
+    settingsInit();
+
     // 1. Display + LVGL (must come before WiFi to show boot message early)
     smartdisplay_init();          // init ST7262 display + GT911 touch
     lv_init();                    // LVGL core init
 
-    Serial.println("[Main] Display initialised");
+    // Set rotation to portrait (270 degrees relative to landscape)
+    lv_display_t* disp = lv_display_get_default();
+    if (disp) {
+        lv_display_set_rotation(disp, LV_DISPLAY_ROTATION_270);
+    }
+
+    Serial.println("[Main] Display initialised (Portrait)");
 
     // 2. WiFi (blocking – restarts if it cannot connect)
     wifiConnect();
@@ -57,6 +68,12 @@ void setup() {
 // loop
 // ------------------------------------------------------------------
 void loop() {
+    // Update LVGL tick
+    static uint32_t lastTick = 0;
+    uint32_t currentTick = millis();
+    lv_tick_inc(currentTick - lastTick);
+    lastTick = currentTick;
+
     // LVGL timer handler – must be called frequently (every few ms)
     lv_timer_handler();
 
@@ -72,4 +89,16 @@ void loop() {
 
     // WiFi reconnect guard
     wifiReconnectIfNeeded();
+
+    // Screen Auto-Sleep Logic (Check every loop)
+    uint32_t inactiveMs = lv_display_get_inactive_time(lv_display_get_default());
+    if (!g_isScreenSleeping && inactiveMs >= DISPLAY_SLEEP_TIMEOUT_MS) {
+        g_isScreenSleeping = true;
+        smartdisplay_lcd_set_backlight(0.0f); // Turn off backlight completely
+        Serial.println("[Main] Screen sleeping due to 30 min inactivity");
+    } else if (g_isScreenSleeping && inactiveMs < DISPLAY_SLEEP_TIMEOUT_MS) {
+        g_isScreenSleeping = false;
+        smartdisplay_lcd_set_backlight(1.0f); // Wake up full brightness
+        Serial.println("[Main] Screen touched, waking up!");
+    }
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,0 +1,28 @@
+#include "settings.h"
+#include "config.h"
+#include <Preferences.h>
+#include <Arduino.h>
+
+static Preferences preferences;
+static char g_activeTapId[32] = {0};
+
+void settingsInit() {
+    preferences.begin("gotap", false);
+    
+    String savedId = preferences.getString("tapId", TAP_ID);
+    strlcpy(g_activeTapId, savedId.c_str(), sizeof(g_activeTapId));
+    
+    Serial.printf("[Settings] Active Tap ID: %s (Default in config: %s)\n", g_activeTapId, TAP_ID);
+}
+
+const char* settingsGetTapId() {
+    return g_activeTapId;
+}
+
+void settingsSetTapId(const char* tapId) {
+    if (!tapId || strlen(tapId) == 0) return;
+    
+    strlcpy(g_activeTapId, tapId, sizeof(g_activeTapId));
+    preferences.putString("tapId", tapId);
+    Serial.printf("[Settings] Saved new Tap ID to NVS: %s\n", tapId);
+}

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -10,6 +10,7 @@
 
 #include "ui.h"
 #include "api_client.h"
+#include "settings.h"
 
 #include <Arduino.h>
 #include <lvgl.h>
@@ -21,11 +22,18 @@
 // ------------------------------------------------------------------
 static lv_obj_t* g_screenIdle  = nullptr;
 static lv_obj_t* g_screenPour  = nullptr;
+static lv_obj_t* g_screenConfig= nullptr;
 static TapData   g_currentData = {};
+static TapList   g_tapList     = {};
+
+static lv_obj_t* g_tapListContainer = nullptr;
+
+extern uint32_t g_lastRefreshMs;
 
 // Idle-screen widgets
-static lv_obj_t* g_imgLogo     = nullptr;
-static lv_obj_t* g_labelName   = nullptr;
+static lv_obj_t* g_logoContainer = nullptr;
+static lv_obj_t* g_imgLogo       = nullptr;
+static lv_obj_t* g_labelName     = nullptr;
 static lv_obj_t* g_labelAbv    = nullptr;
 static lv_obj_t* g_labelVolume = nullptr;
 static lv_obj_t* g_spinnerLoad = nullptr;
@@ -37,24 +45,28 @@ static uint8_t*       g_logoBuffer    = nullptr;
 static size_t         g_logoBufferSz  = 0;
 
 // ------------------------------------------------------------------
-// Colour palette (LVGL v9: lv_color_make)
+// Colour palette (Tæsse ØlVerksted)
 // ------------------------------------------------------------------
-#define COL_BG      lv_color_make(0x12, 0x12, 0x1E)
-#define COL_ACCENT  lv_color_make(0xF5, 0xA6, 0x23)
+#define COL_BG      lv_color_make(0x2B, 0x2D, 0x30)
+#define COL_ACCENT  lv_color_make(0xF3, 0x9C, 0x12)
 #define COL_WHITE   lv_color_make(0xFF, 0xFF, 0xFF)
 #define COL_GREEN   lv_color_make(0x2E, 0xCC, 0x71)
-#define COL_BTN_BG  lv_color_make(0x1E, 0x1E, 0x32)
+#define COL_BTN_BG  lv_color_make(0x3B, 0x3D, 0x40)
 #define COL_CANCEL  lv_color_make(0x80, 0x20, 0x20)
-#define COL_GREY    lv_color_make(0x80, 0x80, 0x80)
+#define COL_GREY    lv_color_make(0xA0, 0xA0, 0xA0)
 
 // ------------------------------------------------------------------
 // Forward declarations
 // ------------------------------------------------------------------
 static void buildIdleScreen();
 static void buildPourScreen();
+static void buildConfigScreen();
 static void logoTapCb(lv_event_t* e);
 static void pourBtnCb(lv_event_t* e);
 static void cancelBtnCb(lv_event_t* e);
+static void settingsBtnCb(lv_event_t* e);
+static void tapSelectedCb(lv_event_t* e);
+static void cancelConfigBtnCb(lv_event_t* e);
 static void confirmTimerCb(lv_timer_t* t);
 static bool downloadLogo(const char* url);
 
@@ -69,8 +81,12 @@ void uiInit() {
     g_screenPour = lv_obj_create(nullptr);
     lv_obj_set_style_bg_color(g_screenPour, COL_BG, 0);
 
+    g_screenConfig = lv_obj_create(nullptr);
+    lv_obj_set_style_bg_color(g_screenConfig, COL_BG, 0);
+
     buildIdleScreen();
     buildPourScreen();
+    buildConfigScreen();
 
     lv_screen_load(g_screenIdle);
 }
@@ -79,7 +95,7 @@ void uiShowIdle(const TapData& data) {
     memcpy(&g_currentData, &data, sizeof(TapData));
 
     if (data.isEmpty) {
-        lv_obj_add_flag(g_imgLogo,     LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(g_logoContainer, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(g_labelName,   LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(g_labelAbv,    LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(g_labelVolume, LV_OBJ_FLAG_HIDDEN);
@@ -92,10 +108,11 @@ void uiShowIdle(const TapData& data) {
         lv_refr_now(nullptr);
 
         if (downloadLogo(data.logoUrl)) {
+            lv_image_cache_drop(&g_logoDsc);
             lv_image_set_src(g_imgLogo, &g_logoDsc);
-            lv_obj_remove_flag(g_imgLogo, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_remove_flag(g_logoContainer, LV_OBJ_FLAG_HIDDEN);
         } else {
-            lv_obj_add_flag(g_imgLogo, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(g_logoContainer, LV_OBJ_FLAG_HIDDEN);
         }
 
         lv_obj_add_flag(g_spinnerLoad, LV_OBJ_FLAG_HIDDEN);
@@ -115,7 +132,9 @@ void uiShowIdle(const TapData& data) {
         lv_obj_remove_flag(g_labelVolume, LV_OBJ_FLAG_HIDDEN);
     }
 
-    lv_screen_load_anim(g_screenIdle, LV_SCR_LOAD_ANIM_FADE_IN, 200, 0, false);
+    if (lv_screen_active() != g_screenIdle) {
+        lv_screen_load_anim(g_screenIdle, LV_SCR_LOAD_ANIM_FADE_IN, 200, 0, false);
+    }
 }
 
 void uiShowPourSelector(const TapData& data) {
@@ -142,8 +161,81 @@ void uiShowConfirmation() {
 }
 
 // ------------------------------------------------------------------
+// Custom Stream for PSRAM Logo Buffer
+// ------------------------------------------------------------------
+class LogoStream : public Stream {
+private:
+    uint8_t* _buf;
+    size_t _cap;
+    size_t _len;
+
+public:
+    LogoStream(uint8_t* buf, size_t cap) : _buf(buf), _cap(cap), _len(0) {}
+
+    size_t write(uint8_t data) override {
+        if (_len < _cap) {
+            _buf[_len++] = data;
+            return 1;
+        }
+        return 0; // Buffer full
+    }
+
+    size_t write(const uint8_t *buffer, size_t size) override {
+        size_t space = _cap - _len;
+        size_t toWrite = (size < space) ? size : space;
+        if (toWrite > 0) {
+            memcpy(_buf + _len, buffer, toWrite);
+            _len += toWrite;
+        }
+        return toWrite;
+    }
+
+    int available() override { return 0; }
+    int read() override { return -1; }
+    int peek() override { return -1; }
+};
+
+// ------------------------------------------------------------------
 // Private: Download logo to PSRAM
 // ------------------------------------------------------------------
+
+// Extractor helper to bypass LVGL v9 memory size bug
+static bool getJpegSize(const uint8_t* data, size_t len, int32_t* w, int32_t* h) {
+    if (len < 4 || data[0] != 0xFF || data[1] != 0xD8) return false;
+    size_t i = 2;
+    while (i < len - 8) {
+        if (data[i] == 0xFF) {
+            uint8_t marker = data[i + 1];
+            if (marker == 0xFF) { i++; continue; } // Padding bytes
+            if (marker == 0xC0 || marker == 0xC1 || marker == 0xC2) { // SOF markers contain dimensions
+                *h = (data[i + 5] << 8) | data[i + 6];
+                *w = (data[i + 7] << 8) | data[i + 8];
+                return true;
+            }
+            if (marker == 0xDA || marker == 0xD9) { // SOS (Start of Scan) or EOI
+                break;
+            }
+            size_t block_len = (data[i + 2] << 8) | data[i + 3];
+            i += 2 + block_len;
+        } else {
+            i++;
+        }
+    }
+    return false;
+}
+
+static bool getPngSize(const uint8_t* data, size_t len, int32_t* w, int32_t* h) {
+    if (len < 24) return false;
+    // PNG signature
+    if (data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47) {
+        // IHDR chunk: width is at offset 16, height at 20
+        *w = (data[16] << 24) | (data[17] << 16) | (data[18] << 8) | data[19];
+        *h = (data[20] << 24) | (data[21] << 16) | (data[22] << 8) | data[23];
+        return true;
+    }
+    return false;
+}
+
 static bool downloadLogo(const char* url) {
     if (!url || url[0] == '\0' || WiFi.status() != WL_CONNECTED) return false;
 
@@ -151,36 +243,100 @@ static bool downloadLogo(const char* url) {
     http.setTimeout(5000);
     http.begin(url);
     int code = http.GET();
+    Serial.printf("[UI] Downloading logo from: %s (Code: %d)\n", url, code);
     if (code != HTTP_CODE_OK) { http.end(); return false; }
 
     int len = http.getSize();
-    if (len <= 0 || len > 200 * 1024) { http.end(); return false; }
+    // Add 32 bytes padding to safely inject the dummy JFIF block if needed
+    size_t allocSz = ((len > 0) ? (size_t)len : 2500 * 1024) + 32; 
+    
+    if (len <= 0) Serial.println("[UI] Logo size unknown (chunked?) - using 2.5MB buffer");
 
-    if (!g_logoBuffer || g_logoBufferSz < (size_t)len) {
+    if (allocSz > 3000 * 1024) { 
+        Serial.printf("[UI] Logo too large: %d bytes\n", len);
+        http.end(); 
+        return false; 
+    }
+
+    if (!g_logoBuffer || g_logoBufferSz < allocSz) {
         free(g_logoBuffer);
-        g_logoBuffer   = (uint8_t*)heap_caps_malloc(len, MALLOC_CAP_SPIRAM);
-        g_logoBufferSz = g_logoBuffer ? (size_t)len : 0;
+        g_logoBuffer   = (uint8_t*)heap_caps_malloc(allocSz, MALLOC_CAP_SPIRAM);
+        g_logoBufferSz = g_logoBuffer ? allocSz : 0;
     }
     if (!g_logoBuffer) { Serial.println("[UI] PSRAM alloc failed"); http.end(); return false; }
 
-    WiFiClient* stream = http.getStreamPtr();
-    size_t rx = 0;
-    while (http.connected() && rx < (size_t)len) {
-        if (stream->available()) rx += stream->readBytes(g_logoBuffer + rx, len - rx);
-    }
+    // Use custom Stream wrapper to properly handle chunked decoding (writeToStream handles the decoding chunk headers)
+    LogoStream ls(g_logoBuffer, g_logoBufferSz);
+    int written = http.writeToStream(&ls);
     http.end();
-    if (rx != (size_t)len) return false;
+    
+    if (written <= 0) {
+        Serial.printf("[UI] Download failed or empty: %d\n", written);
+        return false;
+    }
+    
+    if (len > 0 && written != len) {
+        Serial.printf("[UI] Download mismatch: expected %d, got %d\n", len, written);
+        return false;
+    }
 
-    // LVGL v9 image descriptor (raw JPEG, let tjpgd decode on draw)
+    size_t rx = (size_t)written;
+
+    // Log the first few bytes to verify format (JPEG: FF D8 FF...)
+    if (rx > 4) {
+        Serial.printf("[UI] Header bytes: %02X %02X %02X %02X\n", 
+                      g_logoBuffer[0], g_logoBuffer[1], g_logoBuffer[2], g_logoBuffer[3]);
+    }
+
+    // LVGL v9 BUG WORKAROUND:
+    // LVGL's internal `is_jpg()` strictly requires an APP0 "JFIF" marker block
+    // to identify a JPEG, but many APIs return valid stripped JPEGs (e.g. FF D8 FF DB...).
+    // If we detect a stripped JPEG, we inject a dummy JFIF APP0 block.
+    if (rx > 4 && g_logoBuffer[0] == 0xFF && g_logoBuffer[1] == 0xD8 && g_logoBuffer[2] != 0xE0) {
+        const uint8_t jfif_app0[18] = {
+            0xFF, 0xE0, 0x00, 0x10, 
+            0x4A, 0x46, 0x49, 0x46, 0x00, 
+            0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00
+        };
+        
+        // Ensure we have enough capacity
+        if (rx + 18 <= g_logoBufferSz) {
+            memmove(&g_logoBuffer[2 + 18], &g_logoBuffer[2], rx - 2);
+            memcpy(&g_logoBuffer[2], jfif_app0, 18);
+            rx += 18;
+            Serial.println("[UI] Applied dummy JFIF APP0 header to bypass LVGL v9 bug");
+        } else {
+            Serial.println("[UI] Buffer too small to inject JFIF header!");
+        }
+    }
+
+    // LVGL v9 image descriptor (raw JPEG/PNG)
     g_logoDsc = {};
     g_logoDsc.header.magic    = LV_IMAGE_HEADER_MAGIC;
     g_logoDsc.header.cf       = LV_COLOR_FORMAT_RAW;
-    g_logoDsc.header.w        = 300; // display size (LVGL will scale)
-    g_logoDsc.header.h        = 300;
+    g_logoDsc.header.w        = 0; 
+    g_logoDsc.header.h        = 0;
     g_logoDsc.data_size       = (uint32_t)rx;
     g_logoDsc.data            = g_logoBuffer;
 
-    Serial.printf("[UI] Logo: %u bytes\n", rx);
+    // LVGL BUG WORKAROUND: Raw memory sources require explicit Width and Height!
+    int32_t jw = 0, jh = 0;
+    if (getJpegSize(g_logoBuffer, rx, &jw, &jh)) {
+        g_logoDsc.header.cf = LV_COLOR_FORMAT_RAW;
+        g_logoDsc.header.w = jw;
+        g_logoDsc.header.h = jh;
+        Serial.printf("[UI] Parsed physical JPEG dimensions: %lux%lu\n", jw, jh);
+    } else if (getPngSize(g_logoBuffer, rx, &jw, &jh)) {
+        g_logoDsc.header.cf = LV_COLOR_FORMAT_RAW_ALPHA;
+        g_logoDsc.header.w = jw;
+        g_logoDsc.header.h = jh;
+        Serial.printf("[UI] Parsed physical PNG dimensions: %lux%lu\n", jw, jh);
+    } else {
+        Serial.printf("[UI] Failed to parse image dimensions. LVGL decoding might abort.\n");
+    }
+
+    Serial.printf("[UI] MEMFS Driver for 'M': %s\n", lv_fs_is_ready('M') ? "READY" : "NOT READY");
+    Serial.printf("[UI] Logo: %u bytes received (Buffer: %p, DSC Size: %u)\n", (uint32_t)rx, g_logoBuffer, g_logoDsc.data_size);
     return true;
 }
 
@@ -193,31 +349,39 @@ static void buildIdleScreen() {
     lv_obj_center(g_spinnerLoad);
     lv_obj_add_flag(g_spinnerLoad, LV_OBJ_FLAG_HIDDEN);
 
-    g_imgLogo = lv_image_create(g_screenIdle);
-    lv_obj_set_size(g_imgLogo, 300, 300);
-    lv_obj_align(g_imgLogo, LV_ALIGN_CENTER, 0, -50);
-    lv_obj_add_flag(g_imgLogo, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_add_flag(g_imgLogo, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_event_cb(g_imgLogo, logoTapCb, LV_EVENT_CLICKED, nullptr);
+    g_logoContainer = lv_obj_create(g_screenIdle);
+    lv_obj_set_size(g_logoContainer, 300, 300);
+    lv_obj_set_style_radius(g_logoContainer, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_clip_corner(g_logoContainer, true, 0);
+    lv_obj_set_style_border_width(g_logoContainer, 0, 0);
+    lv_obj_clear_flag(g_logoContainer, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_align(g_logoContainer, LV_ALIGN_CENTER, 0, -120);
+    lv_obj_add_flag(g_logoContainer, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(g_logoContainer, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_event_cb(g_logoContainer, logoTapCb, LV_EVENT_CLICKED, nullptr);
+
+    g_imgLogo = lv_image_create(g_logoContainer);
+    lv_obj_center(g_imgLogo);
 
     g_labelName = lv_label_create(g_screenIdle);
-    lv_obj_set_style_text_font(g_labelName, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_font(g_labelName, &lv_font_montserrat_36, 0);
     lv_obj_set_style_text_color(g_labelName, COL_WHITE, 0);
-    lv_label_set_long_mode(g_labelName, LV_LABEL_LONG_SCROLL_CIRCULAR);
-    lv_obj_set_width(g_labelName, 700);
-    lv_obj_align(g_labelName, LV_ALIGN_BOTTOM_MID, 0, -100);
+    lv_obj_set_style_text_align(g_labelName, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_long_mode(g_labelName, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(g_labelName, 440);
+    lv_obj_align(g_labelName, LV_ALIGN_BOTTOM_MID, 0, -220);
     lv_obj_add_flag(g_labelName, LV_OBJ_FLAG_HIDDEN);
 
     g_labelAbv = lv_label_create(g_screenIdle);
-    lv_obj_set_style_text_font(g_labelAbv, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_font(g_labelAbv, &lv_font_montserrat_28, 0);
     lv_obj_set_style_text_color(g_labelAbv, COL_ACCENT, 0);
-    lv_obj_align(g_labelAbv, LV_ALIGN_BOTTOM_MID, -100, -65);
+    lv_obj_align(g_labelAbv, LV_ALIGN_BOTTOM_MID, -110, -160);
     lv_obj_add_flag(g_labelAbv, LV_OBJ_FLAG_HIDDEN);
 
     g_labelVolume = lv_label_create(g_screenIdle);
-    lv_obj_set_style_text_font(g_labelVolume, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_font(g_labelVolume, &lv_font_montserrat_28, 0);
     lv_obj_set_style_text_color(g_labelVolume, COL_WHITE, 0);
-    lv_obj_align(g_labelVolume, LV_ALIGN_BOTTOM_MID, 100, -65);
+    lv_obj_align(g_labelVolume, LV_ALIGN_BOTTOM_MID, 110, -160);
     lv_obj_add_flag(g_labelVolume, LV_OBJ_FLAG_HIDDEN);
 
     g_labelEmpty = lv_label_create(g_screenIdle);
@@ -229,40 +393,50 @@ static void buildIdleScreen() {
     lv_obj_add_flag(g_labelEmpty, LV_OBJ_FLAG_HIDDEN);
 
     lv_obj_t* hint = lv_label_create(g_screenIdle);
-    lv_label_set_text(hint, "Trykk på logo for å registrere tapping");
+    lv_label_set_text(hint, "Trykk paa logo for aa registrere tapping");
     lv_obj_set_style_text_font(hint, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(hint, COL_GREY, 0);
     lv_obj_align(hint, LV_ALIGN_BOTTOM_MID, 0, -20);
+
+    lv_obj_t* settingsBtn = lv_button_create(g_screenIdle);
+    lv_obj_set_size(settingsBtn, 60, 60);
+    lv_obj_align(settingsBtn, LV_ALIGN_TOP_RIGHT, -10, 10);
+    lv_obj_set_style_bg_color(settingsBtn, COL_BTN_BG, 0);
+    lv_obj_set_style_radius(settingsBtn, 8, 0);
+    lv_obj_add_event_cb(settingsBtn, settingsBtnCb, LV_EVENT_CLICKED, nullptr);
+
+    lv_obj_t* settingsLbl = lv_label_create(settingsBtn);
+    lv_label_set_text(settingsLbl, LV_SYMBOL_SETTINGS);
+    lv_obj_set_style_text_font(settingsLbl, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(settingsLbl, COL_WHITE, 0);
+    lv_obj_center(settingsLbl);
 }
 
 static void buildPourScreen() {
     lv_obj_t* title = lv_label_create(g_screenPour);
-    lv_label_set_text(title, "Velg størrelse");
-    lv_obj_set_style_text_font(title, &lv_font_montserrat_28, 0);
+    lv_label_set_text(title, "Velg stoerrelse");
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_36, 0);
     lv_obj_set_style_text_color(title, COL_WHITE, 0);
     lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 30);
 
     static const float  pourSizes[]  = {0.25f, 0.33f, 0.44f, 0.50f};
     static const char*  pourLabels[] = {"0,25 L", "0,33 L", "0,44 L", "0,50 L"};
 
-    const int btnW = 300, btnH = 130, gapX = 20, gapY = 20;
+    const int btnW = 400, btnH = 100, gapY = 20;
     for (int i = 0; i < 4; i++) {
-        int col  = i % 2;
-        int row  = i / 2;
-        int xPos = col == 0 ? -(btnW / 2 + gapX / 2) : (btnW / 2 + gapX / 2);
-        int yPos = row == 0 ? -(btnH / 2 + gapY / 2) + 20 : (btnH / 2 + gapY / 2) + 20;
+        int yPos = -120 + i * (btnH + gapY);
 
-        lv_obj_t* btn = lv_button_create(g_screenPour); // LVGL v9: lv_button_create
+        lv_obj_t* btn = lv_button_create(g_screenPour);
         lv_obj_set_size(btn, btnW, btnH);
-        lv_obj_align(btn, LV_ALIGN_CENTER, xPos, yPos);
-        lv_obj_set_style_bg_color(btn, COL_BTN_BG, 0);
-        lv_obj_set_style_bg_color(btn, COL_ACCENT, LV_STATE_PRESSED);
+        lv_obj_align(btn, LV_ALIGN_CENTER, 0, yPos);
+        lv_obj_set_style_bg_color(btn, COL_ACCENT, 0); // Orange by default
+        lv_obj_set_style_bg_color(btn, COL_BTN_BG, LV_STATE_PRESSED); // Dark grey on press
         lv_obj_set_style_radius(btn, 16, 0);
         lv_obj_add_event_cb(btn, pourBtnCb, LV_EVENT_CLICKED, (void*)&pourSizes[i]);
 
         lv_obj_t* lbl = lv_label_create(btn);
         lv_label_set_text(lbl, pourLabels[i]);
-        lv_obj_set_style_text_font(lbl, &lv_font_montserrat_28, 0);
+        lv_obj_set_style_text_font(lbl, &lv_font_montserrat_32, 0);
         lv_obj_set_style_text_color(lbl, COL_WHITE, 0);
         lv_obj_center(lbl);
     }
@@ -276,6 +450,41 @@ static void buildPourScreen() {
 
     lv_obj_t* cancelLbl = lv_label_create(cancelBtn);
     lv_label_set_text(cancelLbl, LV_SYMBOL_CLOSE);
+    lv_obj_set_style_text_font(cancelLbl, &lv_font_montserrat_32, 0);
+    lv_obj_set_style_text_color(cancelLbl, COL_WHITE, 0);
+    lv_obj_center(cancelLbl);
+}
+
+static void buildConfigScreen() {
+    lv_obj_t* title = lv_label_create(g_screenConfig);
+    lv_label_set_text(title, "Velg Kran");
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_36, 0);
+    lv_obj_set_style_text_color(title, COL_WHITE, 0);
+    lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 30);
+
+    g_tapListContainer = lv_obj_create(g_screenConfig);
+    lv_obj_set_size(g_tapListContainer, 440, 300);
+    lv_obj_align(g_tapListContainer, LV_ALIGN_CENTER, 0, -10);
+    lv_obj_set_style_bg_opa(g_tapListContainer, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(g_tapListContainer, 0, 0);
+    
+    // Sett opp flex layout for knappene
+    lv_obj_set_flex_flow(g_tapListContainer, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_style_pad_row(g_tapListContainer, 15, 0);
+    lv_obj_set_style_pad_column(g_tapListContainer, 15, 0);
+    lv_obj_set_flex_align(g_tapListContainer, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    // Bare avbryt-knapp trengs nå
+    int btnW = 180, btnH = 80;
+    lv_obj_t* cancelBtn = lv_button_create(g_screenConfig);
+    lv_obj_set_size(cancelBtn, btnW, btnH);
+    lv_obj_align(cancelBtn, LV_ALIGN_BOTTOM_MID, 0, -20);
+    lv_obj_set_style_bg_color(cancelBtn, COL_CANCEL, 0);
+    lv_obj_set_style_radius(cancelBtn, 12, 0);
+    lv_obj_add_event_cb(cancelBtn, cancelConfigBtnCb, LV_EVENT_CLICKED, nullptr);
+
+    lv_obj_t* cancelLbl = lv_label_create(cancelBtn);
+    lv_label_set_text(cancelLbl, "Avbryt");
     lv_obj_set_style_text_font(cancelLbl, &lv_font_montserrat_28, 0);
     lv_obj_set_style_text_color(cancelLbl, COL_WHITE, 0);
     lv_obj_center(cancelLbl);
@@ -294,6 +503,7 @@ static void pourBtnCb(lv_event_t* e) {
     if (!liters) return;
     Serial.printf("[UI] Pour: %.2f L\n", *liters);
     if (postPour(g_currentData.kegId, *liters)) {
+        g_lastRefreshMs = 0; // Force immediate API fetch in main loop
         uiShowConfirmation();
     } else {
         lv_screen_load_anim(g_screenIdle, LV_SCR_LOAD_ANIM_FADE_IN, 200, 0, false);
@@ -309,4 +519,71 @@ static void confirmTimerCb(lv_timer_t* t) {
     lv_obj_t* overlay = (lv_obj_t*)lv_timer_get_user_data(t);
     if (overlay) lv_obj_delete(overlay); // LVGL v9: lv_obj_delete (not lv_obj_del)
     lv_timer_delete(t);                  // LVGL v9: lv_timer_delete (not lv_timer_del)
+}
+
+static void tapSelectedCb(lv_event_t* e) {
+    int tapId = *(int*)lv_event_get_user_data(e);
+    char newId[16];
+    snprintf(newId, sizeof(newId), "%d", tapId);
+    settingsSetTapId(newId);
+    Serial.printf("[UI] Saved new tap ID %s, restarting...\n", newId);
+    delay(100);
+    ESP.restart();
+}
+
+static void settingsBtnCb(lv_event_t* e) {
+    (void)e;
+    
+    // Tøm container for gamle knapper
+    lv_obj_clean(g_tapListContainer);
+
+    if (fetchTapsList(g_tapList)) {
+        if (g_tapList.count == 0) {
+            lv_obj_t* lbl = lv_label_create(g_tapListContainer);
+            lv_label_set_text(lbl, "Ingen kraner funnet");
+            lv_obj_set_style_text_color(lbl, COL_WHITE, 0);
+        } else {
+            const char* currentIdStr = settingsGetTapId();
+            int currentId = atoi(currentIdStr);
+
+            for (int i = 0; i < g_tapList.count; i++) {
+                lv_obj_t* btn = lv_button_create(g_tapListContainer);
+                lv_obj_set_size(btn, 170, 80);
+                
+                // Gjør den aktive kranen grønn, resten oransje
+                if (g_tapList.taps[i].id == currentId) {
+                    lv_obj_set_style_bg_color(btn, COL_GREEN, 0);
+                } else {
+                    lv_obj_set_style_bg_color(btn, COL_ACCENT, 0); // Oransje
+                    lv_obj_set_style_bg_color(btn, COL_BTN_BG, LV_STATE_PRESSED);
+                }
+                lv_obj_set_style_radius(btn, 12, 0);
+                lv_obj_add_event_cb(btn, tapSelectedCb, LV_EVENT_CLICKED, &g_tapList.taps[i].id);
+
+                lv_obj_t* lbl = lv_label_create(btn);
+                char buf[64];
+                snprintf(buf, sizeof(buf), "Kran %s", g_tapList.taps[i].name);
+                lv_label_set_text(lbl, buf);
+                lv_obj_set_style_text_font(lbl, &lv_font_montserrat_28, 0);
+                lv_obj_set_style_text_color(lbl, COL_WHITE, 0);
+                
+                // Forhindre at lange navn sprenger knappen:
+                lv_label_set_long_mode(lbl, LV_LABEL_LONG_SCROLL_CIRCULAR);
+                lv_obj_set_width(lbl, 150);
+                
+                lv_obj_center(lbl);
+            }
+        }
+    } else {
+        lv_obj_t* lbl = lv_label_create(g_tapListContainer);
+        lv_label_set_text(lbl, "Feil ved oppslag");
+        lv_obj_set_style_text_color(lbl, COL_WHITE, 0);
+    }
+
+    lv_screen_load_anim(g_screenConfig, LV_SCR_LOAD_ANIM_MOVE_LEFT, 200, 0, false);
+}
+
+static void cancelConfigBtnCb(lv_event_t* e) {
+    (void)e;
+    lv_screen_load_anim(g_screenIdle, LV_SCR_LOAD_ANIM_MOVE_RIGHT, 200, 0, false);
 }


### PR DESCRIPTION
# Omfattende Config-skjerm, UI & Minnefiks

Løser/lukker issue #4

Dette er alle endringene gjort under oppgaven for å konfigurere tappeklan på skjerm + alle minneproblemene relatert til nedlasting/dekoding av logoer.

## Hva er gjort
- **NVS-lagring (`settings.h/cpp`)**: Valgt kran-ID lagres nå lokalt på skjermens flash og brukes automatisk ved oppstart (fallback til config.h).
- **Config UI (`ui.cpp`)**: Ny modal med grid av knapper, hvor lister opp pre-hentet API data direkte fra `/api/taps`. Aktiv kran indikeres med grønn knapp. Knappetrykk lagrer og tar direkte soft-reset (for å cleare UI).
- **Memory Fix (`lv_conf.h`)**: Aktivert og økt `LV_CACHE_DEF_SIZE` til 4 MB for å få reservert plass i PSRAM, istedenfor at LodePNG (som pakker ut png i bulk) tryner på grunn av manglende allokeringsplass. 
- **Tekst-Wrap (`ui.cpp`)**: `LV_LABEL_LONG_SCROLL_CIRCULAR` brøt i stykker designet (med skygger/ghosting og hopping av tekst) når ølnavnene inneholdt mellomrom da den var strippet for fast høyde. Returnert til "normal" breddebasert `LV_LABEL_LONG_WRAP`. Skjermanimasjonen er gjort betinget for å ikke dobbelt-animere på seg selv hvert 60 sekunder.
- **PSRAM chunk buffer (`ui.cpp`)**: Satt buffer size til hele 2.5 MB ved chunked transfer (ingen Content-Length) slik at buffer size array (på PSRAM) ikke trigger "short write"/Overflow i stream-wrapperen.
- **PNG dimensjoner (`ui.cpp/h`)**: Lagt til `getPngSize()` parser for de første 24 bytes av raw memory for å slippe LVGL bug som krever definert `w` og `h` i raw descriptor.

**Testing:**
- [x] Testet og fungerer via PlarformIO lokal opplastning til fysisk enhet.
