### PR TITLE
fix: correct version commit count calculation

### DIFF
--- a/.github/workflows/pio_build.yml
+++ b/.github/workflows/pio_build.yml
@@ -57,10 +57,13 @@ jobs:
           YEAR=$(date +%Y)
           MONTH=$(date +%m)
 
-          # Get commit count since last tag for version component
-          if git describe --tags --always --long >/dev/null 2>&1; then
-            COMMIT_COUNT=$(git describe --tags --always --long | sed 's/.*-\([0-9]*\)-g.*/\1/')
+          # Get commit count since last tag (not including the tag itself)
+          # If no tags exist, count all commits
+          if git describe --tags --abbrev=0 >/dev/null 2>&1; then
+            # Tags exist - count commits since last tag
+            COMMIT_COUNT=$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count 2>/dev/null || echo "0")
           else
+            # No tags - count all commits
             COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "0")
           fi
 

--- a/scripts/version_gen.py
+++ b/scripts/version_gen.py
@@ -32,23 +32,28 @@ def get_git_branch():
         return "unknown"
 
 def get_commit_count_since_tag():
-    """Get commit count since last tag using git describe."""
+    """Get commit count since last tag (not including the tag itself).
+    
+    If no tags exist, count all commits from the beginning.
+    """
     try:
-        # --long ensures we always get commit count even if we're exactly on a tag
-        # Format: TAG-N-HASH (e.g., v2026.03.0-5-g1234567)
+        # First, check if any tags exist
         result = subprocess.run(
-            ["git", "describe", "--tags", "--always", "--long"],
+            ["git", "describe", "--tags", "--abbrev=0"],
             capture_output=True,
             text=True,
             check=True
         )
-        output = result.stdout.strip()
+        last_tag = result.stdout.strip()
         
-        # Parse the output to get commit count
-        parts = output.split("-")
-        if len(parts) >= 2 and parts[-2].isdigit():
-            return parts[-2]  # Commit count
-        return "0"
+        # Count commits since last tag
+        result = subprocess.run(
+            ["git", "rev-list", f"{last_tag}..HEAD", "--count"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
     except subprocess.CalledProcessError:
         # No tags exist, count all commits
         try:


### PR DESCRIPTION
## Summary

Fikser versjonsformatet slik at det viser faktisk commit-count i stedet for commit-hash.

## What & Why

**Problem:** Når ingen Git-tags finnes, returnerte `git describe --tags --always --long` commit-hash (f.eks. `5663f08`) i stedet for commit-count. Dette ga versjoner som:
- ❌ `2026.03.5663f08-dev` (commit-hash)

**Løsning:** Bruk `git describe --tags --abbrev=0` for å finne siste tag, og tell deretter commits fra den taggen til HEAD:
- ✅ `2026.03.30-dev` (faktisk commit-count)

## Type of Change

- [ ] ✨ Ny funksjonalitet
- [x] 🐛 Bugfix
- [ ] 📝 Dokumentasjon
- [ ] ♻️ Refaktorering
- [ ] ⚡️ Performance
- [ ] 🔧 Konfigurasjon
- [ ] 🧪 Testing
- [ ] 🏗 CI/CD

## Testing Performed

- [x] Script testet lokalt - viser korrekt commit count (2026.03.30)
- [ ] CI/CD vil teste ved merge

## Deployment Notes

**Etter merge:** Når denne er merget, vil neste build gi korrekt versjonsnummer. 

**Fremtidig tag:** Når vi lager en tag (f.eks. `v2026.03.0`), vil commit-counten starte fra null igjen for commits etter taggen.

## Related Issues

Relatert til #11 (implementerte versjonshåndtering)

## Reviewer Checklist

- [ ] Logikken for commit-counting er korrekt
- [ ] Både workflow og Python-script er konsistente
- [ ] Ingen breaking changes
