### PR TITLE
feat: add tap header and branch indicator to idle screen (fixes #9)

### DIFF
--- a/include/api_client.h
+++ b/include/api_client.h
@@ -81,3 +81,11 @@ bool fetchTapsList(TapList& out);
  * @return true on success (even if no update available), false on error.
  */
 bool fetchOtaUpdateInfo(const char* currentVersion, const char* targetBranch, OtaUpdateInfo& out);
+
+/**
+ * @brief Update target branch for current tap.
+ * @param tapId     Tap ID string.
+ * @param branch    New branch name ("main" or "development").
+ * @return true on success (HTTP 204), false on error.
+ */
+bool updateTapBranch(const char* tapId, const char* branch);

--- a/src/api_client.cpp
+++ b/src/api_client.cpp
@@ -202,3 +202,30 @@ bool fetchOtaUpdateInfo(const char* currentVersion, const char* targetBranch, Ot
 
     return true;
 }
+
+bool updateTapBranch(const char* tapId, const char* branch) {
+    if (!tapId || !branch) return false;
+
+    char url[256];
+    snprintf(url, sizeof(url), "%s/api/taps/%s/branch", API_BASE_URL, tapId);
+
+    // Build JSON body manually (no need for ArduinoJson here)
+    char jsonBody[64];
+    snprintf(jsonBody, sizeof(jsonBody), "{\"targetBranch\":\"%s\"}", branch);
+
+    HTTPClient http;
+    http.begin(url);
+    http.addHeader("Content-Type", "application/json");
+
+    int httpCode = http.PUT(jsonBody);
+    bool success = (httpCode == 204 || httpCode == 200);
+
+    if (success) {
+        Serial.printf("[API] PUT %s - Branch updated to %s\n", url, branch);
+    } else {
+        Serial.printf("[API] PUT %s - Failed: %d\n", url, httpCode);
+    }
+
+    http.end();
+    return success;
+}

--- a/src/api_client.cpp
+++ b/src/api_client.cpp
@@ -207,7 +207,8 @@ bool updateTapBranch(const char* tapId, const char* branch) {
     if (!tapId || !branch) return false;
 
     char url[256];
-    snprintf(url, sizeof(url), "%s/api/taps/%s/branch", API_BASE_URL, tapId);
+    // API_BASE_URL already includes /api, so we use /taps/{id}/branch directly
+    snprintf(url, sizeof(url), "%s/taps/%s/branch", API_BASE_URL, tapId);
 
     // Build JSON body manually (no need for ArduinoJson here)
     char jsonBody[64];

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -560,8 +560,6 @@ static void buildConfigScreen() {
     lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_style_pad_column(footer, 20, 0);
 
-    int btnW = 180, btnH = 80;
-
     // Omstart-knapp
     lv_obj_t* rebootBtn = lv_button_create(footer);
     lv_obj_set_size(rebootBtn, btnW, btnH);

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -36,6 +36,10 @@ static lv_obj_t* g_tapListContainer = nullptr;
 static lv_obj_t* g_btnMain = nullptr;
 static lv_obj_t* g_btnDev = nullptr;
 
+// Idle screen elements for issue #9
+static lv_obj_t* g_labelTapTitle = nullptr;
+static lv_obj_t* g_iconBranch = nullptr;
+
 extern uint32_t g_lastRefreshMs;
 
 // Idle-screen widgets
@@ -104,6 +108,22 @@ void uiInit() {
 
 void uiShowIdle(const TapData& data) {
     memcpy(&g_currentData, &data, sizeof(TapData));
+
+    // Oppdater overskrift med kran-nummer (issue #9)
+    char titleBuf[32];
+    const char* tapId = settingsGetTapId();
+    snprintf(titleBuf, sizeof(titleBuf), "Kran %s", tapId);
+    lv_label_set_text(g_labelTapTitle, titleBuf);
+
+    // Oppdater branch-ikon (issue #9)
+    const char* branch = settingsGetTargetBranch();
+    if (strcmp(branch, "development") == 0) {
+        lv_label_set_text(g_iconBranch, LV_SYMBOL_WARNING " DEV");
+        lv_obj_set_style_text_color(g_iconBranch, lv_color_make(0xF3, 0x9C, 0x12), 0);
+    } else {
+        lv_label_set_text(g_iconBranch, LV_SYMBOL_OK " MAIN");
+        lv_obj_set_style_text_color(g_iconBranch, lv_color_make(0x2E, 0xCC, 0x71), 0);
+    }
 
     if (data.isEmpty) {
         lv_obj_add_flag(g_logoContainer, LV_OBJ_FLAG_HIDDEN);
@@ -364,6 +384,31 @@ static void buildIdleScreen() {
     lv_obj_set_size(g_spinnerLoad, 80, 80);
     lv_obj_center(g_spinnerLoad);
     lv_obj_add_flag(g_spinnerLoad, LV_OBJ_FLAG_HIDDEN);
+
+    // --- Issue #9: Overskrift med kran-navn og branch-ikon ---
+    // Overskrift (topp, sentrert)
+    g_labelTapTitle = lv_label_create(g_screenIdle);
+    lv_label_set_text(g_labelTapTitle, "Kran 2");
+    lv_obj_set_style_text_font(g_labelTapTitle, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(g_labelTapTitle, COL_ACCENT, 0);
+    lv_obj_align(g_labelTapTitle, LV_ALIGN_TOP_MID, 0, 15);
+
+    // Branch-ikon (venstre side, ved overskrift)
+    g_iconBranch = lv_label_create(g_screenIdle);
+    const char* branch = settingsGetTargetBranch();
+    if (strcmp(branch, "development") == 0) {
+        lv_label_set_text(g_iconBranch, LV_SYMBOL_WARNING " DEV");  // Advarsel-ikon for dev
+    } else {
+        lv_label_set_text(g_iconBranch, LV_SYMBOL_OK " MAIN");      // Hake-ikon for main
+    }
+    lv_obj_set_style_text_font(g_iconBranch, &lv_font_montserrat_20, 0);
+    if (strcmp(branch, "development") == 0) {
+        lv_obj_set_style_text_color(g_iconBranch, lv_color_make(0xF3, 0x9C, 0x12), 0);  // Oransje for dev
+    } else {
+        lv_obj_set_style_text_color(g_iconBranch, lv_color_make(0x2E, 0xCC, 0x71), 0);  // Grønn for main
+    }
+    lv_obj_align(g_iconBranch, LV_ALIGN_TOP_LEFT, 15, 20);
+    // --- Slutt issue #9 ---
 
     g_logoContainer = lv_obj_create(g_screenIdle);
     lv_obj_set_size(g_logoContainer, 300, 300);

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -14,6 +14,7 @@
 #include "version.h"
 
 #include <Arduino.h>
+#include <cstring>
 
 #ifndef OTA_DEFAULT_BRANCH
 #define OTA_DEFAULT_BRANCH "main"
@@ -32,6 +33,8 @@ static TapData   g_currentData = {};
 static TapList   g_tapList     = {};
 
 static lv_obj_t* g_tapListContainer = nullptr;
+static lv_obj_t* g_btnMain = nullptr;
+static lv_obj_t* g_btnDev = nullptr;
 
 extern uint32_t g_lastRefreshMs;
 
@@ -73,6 +76,8 @@ static void settingsBtnCb(lv_event_t* e);
 static void tapSelectedCb(lv_event_t* e);
 static void cancelConfigBtnCb(lv_event_t* e);
 static void rebootBtnCb(lv_event_t* e);
+static void branchMainCb(lv_event_t* e);
+static void branchDevCb(lv_event_t* e);
 static void confirmTimerCb(lv_timer_t* t);
 static bool downloadLogo(const char* url);
 
@@ -494,6 +499,57 @@ static void buildConfigScreen() {
     lv_obj_set_style_text_color(versionLbl, COL_GREY, 0);
     lv_obj_align(versionLbl, LV_ALIGN_BOTTOM_MID, 0, -15);
 
+    // Branch-velger knapper (over footer)
+    lv_obj_t* branchContainer = lv_obj_create(g_screenConfig);
+    lv_obj_set_size(branchContainer, 440, 100);
+    lv_obj_align(branchContainer, LV_ALIGN_BOTTOM_MID, 0, -110);
+    lv_obj_set_style_bg_opa(branchContainer, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(branchContainer, 0, 0);
+    lv_obj_set_flex_flow(branchContainer, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(branchContainer, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_column(branchContainer, 20, 0);
+
+    int btnW = 180, btnH = 80;
+    const char* currentBranch = settingsGetTargetBranch();
+
+    // Main-knapp
+    g_btnMain = lv_button_create(branchContainer);
+    lv_obj_set_size(g_btnMain, btnW, btnH);
+    lv_obj_set_style_radius(g_btnMain, 12, 0);
+    lv_obj_add_event_cb(g_btnMain, branchMainCb, LV_EVENT_CLICKED, nullptr);
+
+    // Highlight hvis main er valgt
+    if (strcmp(currentBranch, "main") == 0) {
+        lv_obj_set_style_bg_color(g_btnMain, COL_GREEN, 0);
+    } else {
+        lv_obj_set_style_bg_color(g_btnMain, COL_BTN_BG, 0);
+    }
+
+    lv_obj_t* mainLbl = lv_label_create(g_btnMain);
+    lv_label_set_text(mainLbl, "Main");
+    lv_obj_set_style_text_font(mainLbl, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(mainLbl, COL_WHITE, 0);
+    lv_obj_center(mainLbl);
+
+    // Development-knapp
+    g_btnDev = lv_button_create(branchContainer);
+    lv_obj_set_size(g_btnDev, btnW, btnH);
+    lv_obj_set_style_radius(g_btnDev, 12, 0);
+    lv_obj_add_event_cb(g_btnDev, branchDevCb, LV_EVENT_CLICKED, nullptr);
+
+    // Highlight hvis development er valgt
+    if (strcmp(currentBranch, "development") == 0) {
+        lv_obj_set_style_bg_color(g_btnDev, COL_GREEN, 0);
+    } else {
+        lv_obj_set_style_bg_color(g_btnDev, COL_BTN_BG, 0);
+    }
+
+    lv_obj_t* devLbl = lv_label_create(g_btnDev);
+    lv_label_set_text(devLbl, "Development");
+    lv_obj_set_style_text_font(devLbl, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(devLbl, COL_WHITE, 0);
+    lv_obj_center(devLbl);
+
     // Knapper på bunnen (Reboot + Avbryt)
     lv_obj_t* footer = lv_obj_create(g_screenConfig);
     lv_obj_set_size(footer, 440, 100);
@@ -636,4 +692,40 @@ static void rebootBtnCb(lv_event_t* e) {
     Serial.println("[UI] Rebooting requested...");
     delay(100);
     ESP.restart();
+}
+
+static void branchMainCb(lv_event_t* e) {
+    (void)e;
+    Serial.println("[UI] Switching to Main branch...");
+    
+    const char* tapId = settingsGetTapId();
+    if (updateTapBranch(tapId, "main")) {
+        settingsSetTargetBranch("main");
+        
+        // Oppdater UI - highlight Main, fjern highlight fra Dev
+        lv_obj_set_style_bg_color(g_btnMain, COL_GREEN, 0);
+        lv_obj_set_style_bg_color(g_btnDev, COL_BTN_BG, 0);
+        
+        Serial.println("[UI] Branch switched to Main successfully");
+    } else {
+        Serial.println("[UI] Failed to switch branch");
+    }
+}
+
+static void branchDevCb(lv_event_t* e) {
+    (void)e;
+    Serial.println("[UI] Switching to Development branch...");
+    
+    const char* tapId = settingsGetTapId();
+    if (updateTapBranch(tapId, "development")) {
+        settingsSetTargetBranch("development");
+        
+        // Oppdater UI - highlight Dev, fjern highlight fra Main
+        lv_obj_set_style_bg_color(g_btnDev, COL_GREEN, 0);
+        lv_obj_set_style_bg_color(g_btnMain, COL_BTN_BG, 0);
+        
+        Serial.println("[UI] Branch switched to Development successfully");
+    } else {
+        Serial.println("[UI] Failed to switch branch");
+    }
 }


### PR DESCRIPTION
## Summary

Implementerer visning av kran-navn og branch-indikator på hovedskjermen (idle screen).

## What & Why

**Problem (issue #9):** Det er ikke mulig å se hvilken kran eller branch skjermen viser uten å gå inn i config.

**Løsning:**
- **Overskrift på toppen:** Viser "Kran X" (f.eks. "Kran 2")
- **Branch-ikon venstre hjørne:**
  - 🟠 `⚠️ DEV` for development branch
  - 🟢 `✓ MAIN` for main branch

## Type of Change

- [x] ✨ Ny funksjonalitet
- [ ] 🐛 Bugfix
- [ ] 📝 Dokumentasjon
- [ ] ♻️ Refaktorering
- [ ] ⚡️ Performance
- [ ] 🔧 Konfigurasjon
- [ ] 🧪 Testing
- [ ] 🏗 CI/CD

## Testing Performed

- [ ] Build testet (vil testes av CI/CD)
- [ ] Manuell testing på ESP32 gjenstår

## Deployment Notes

**Vises på hovedskjermen:**
```
┌─────────────────────────────────┐
│ ⚠️ DEV          Kran 2          │  ← Toppen av skjermen
│                                 │
│         [Logo]                  │
│                                 │
│    Creative Classic             │
│    5.2% ABV    12.1 L igjen     │
└─────────────────────────────────┘
```

**Oppdateres dynamisk når:**
- Tap ID endres i config
- Branch byttes via branch-selector knappene

## Related Issues

Closes #9

## Reviewer Checklist

- [ ] Overskrift viser korrekt kran-nummer
- [ ] Branch-ikon viser riktig branch (DEV/MAIN)
- [ ] Branch-ikon oppdateres når branch byttes
- [ ] Farger er korrekte (oransje for dev, grønn for main)
- [ ] Layout ser bra ut på skjermen
